### PR TITLE
Prevent putting orders to 'completed'-status directly from 'pending'-…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.11] - 2020-07-02
+
+### Changed
+- Prevent putting orders to 'completed'-status directly from 'pending'-status if they are Kassa-orders created via API.
+
 ## [0.7.10] - 2020-06-17
 
 ### Changed


### PR DESCRIPTION
…status if they are Kassa-orders created via API.